### PR TITLE
Implementação de assinaturas híbridas com a liboqs

### DIFF
--- a/src/crypto/hybrid/hybrid_sig.go
+++ b/src/crypto/hybrid/hybrid_sig.go
@@ -39,6 +39,12 @@ const (
 	CROSS_128_FAST_ED25519  OID = "0.2.1.5.F"
 	CROSS_192_SMALL_ED25519 OID = "0.2.3.5.S"
 	CROSS_256_SMALL_ED25519 OID = "0.2.5.5.S"
+
+	ML_DSA_44_P256 OID = "0.3.1.2"
+	ML_DSA_65_P384 OID = "0.3.1.3"
+	ML_DSA_87_P521 OID = "0.3.1.5"
+
+	ML_DSA_65_ED25519 OID = "0.3.2.2"
 )
 
 type SigName struct {
@@ -66,6 +72,12 @@ var SigOIDtoName = map[OID]SigName{
 	CROSS_128_FAST_ED25519:  {"cross-rsdpg-128-fast", ed25519.PrivateKey{}},
 	CROSS_192_SMALL_ED25519: {"cross-rsdpg-192-small", ed25519.PrivateKey{}},
 	CROSS_256_SMALL_ED25519: {"cross-rsdpg-256-small", ed25519.PrivateKey{}},
+
+	ML_DSA_44_P256: {"ML-DSA-44", elliptic.P256()},
+	ML_DSA_65_P384: {"ML-DSA-65", elliptic.P384()},
+	ML_DSA_87_P521: {"ML-DSA-87", elliptic.P521()},
+
+	ML_DSA_65_ED25519: {"ML-DSA-65", ed25519.PrivateKey{}},
 }
 
 type PublicKey struct {
@@ -82,13 +94,13 @@ type PrivateKey struct {
 }
 
 // GetPublicKeys returns the classic and post-quantum private keys from a sig receiver.
-func (pub *PublicKey) GetPublicKeys() (classic *ecdsa.PublicKey, pqc []byte) {
-	return (*pub.classic).(*ecdsa.PublicKey), pub.pqc
+func (pub *PublicKey) GetPublicKeys() (classic *interface{}, pqc []byte) {
+	return pub.classic, pub.pqc
 }
 
 // GetPrivateKeys returns the classic and post-quantum private keys from a sig receiver.
-func (priv *PrivateKey) GetPrivateKeys() (classic *ecdsa.PrivateKey, pqc []byte) {
-	return (*priv.classic).(*ecdsa.PrivateKey), priv.pqc
+func (priv *PrivateKey) GetPrivateKeys() (classic *interface{}, pqc []byte) {
+	return priv.classic, priv.pqc
 }
 
 // ExportPublicKey exports the corresponding public hybrid key from the sig receiver.

--- a/src/crypto/hybrid/hybrid_sig.go
+++ b/src/crypto/hybrid/hybrid_sig.go
@@ -1,0 +1,127 @@
+// hybrid_sig.go
+// hybrid signature cryptography for the go std library using liboqs-go.
+
+package hybrid
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+
+	"github.com/open-quantum-safe/liboqs-go/oqs"
+	"golang.org/x/crypto/cryptobyte"
+
+	"errors"
+)
+
+// Object IDentifiers for PQC and Composite
+// https://github.com/IETF-Hackathon/pqc-certificates/blob/master/docs/oid_mapping.md
+type OID string
+
+const (
+	MAYO1_P256 OID = "0.1.1.1" // TODO: use proper OID values
+	MAYO2_P256 OID = "0.1.2.2"
+	MAYO3_P384 OID = "0.1.3.3"
+	MAYO5_P521 OID = "0.1.5.4"
+)
+
+const (
+	HYBRID_SIG uint8 = 0 // used for Verify(), which signature to check for
+	PQC_SIG
+	CLASSIC_SIG
+)
+
+type SigName struct {
+	pqc     string
+	classic elliptic.Curve
+}
+
+var SigOIDtoName = map[OID]SigName{
+	MAYO1_P256: {"Mayo-1", elliptic.P256()},
+	MAYO2_P256: {"Mayo-2", elliptic.P256()},
+	MAYO3_P384: {"Mayo-3", elliptic.P384()},
+	MAYO5_P521: {"Mayo-5", elliptic.P521()},
+}
+
+type PublicKey struct {
+	SigOID  OID
+	pqc     []byte
+	classic *ecdsa.PublicKey
+}
+
+type PrivateKey struct {
+	SigOID  OID
+	pqc     []byte
+	classic *ecdsa.PrivateKey
+	public  *PublicKey
+}
+
+func (pub *PublicKey) ExportPublicKeys() (pqc []byte, classic *ecdsa.PublicKey) {
+	return pub.pqc, pub.classic
+}
+
+func (priv *PrivateKey) ExportPublicKeys() (pqc []byte, classic *ecdsa.PublicKey) {
+	return priv.public.pqc, priv.public.classic
+}
+
+func (priv *PrivateKey) ExportPrivateKeys() (pqc []byte, classic *ecdsa.PrivateKey) {
+	return priv.pqc, priv.classic
+}
+
+func GenerateKey(sigOID OID) (priv PrivateKey, err error) {
+	var pub PublicKey
+
+	// Post-quantum LibOQS
+	pqcSigner := oqs.Signature{}
+	if err = pqcSigner.Init(SigOIDtoName[sigOID].pqc, nil); err != nil {
+		return PrivateKey{}, err
+	}
+	if pub.pqc, err = pqcSigner.GenerateKeyPair(); err != nil {
+		return PrivateKey{}, err
+	}
+	priv.pqc = pqcSigner.ExportSecretKey()
+
+	// Classic NIST curves
+	if priv.classic, err = ecdsa.GenerateKey(SigOIDtoName[sigOID].classic, rand.Reader); err != nil {
+		return PrivateKey{}, err
+	}
+	pub.classic = &priv.classic.PublicKey
+
+	pub.SigOID = sigOID
+	priv.SigOID = sigOID
+	priv.public = &pub
+
+	return priv, err
+}
+
+func (priv *PrivateKey) Sign(message []byte) (signature []byte, err error) {
+	var hybridSig cryptobyte.Builder
+	var pqcSig []byte
+	var classicSig []byte
+
+	// Post-quantum LibOQS
+	pqcSigner := oqs.Signature{}
+	if err := pqcSigner.Init(SigOIDtoName[priv.SigOID].pqc, priv.pqc); err != nil {
+		return nil, err
+	}
+	if pqcSig, err = pqcSigner.Sign(message); err != nil {
+		return nil, err
+	}
+
+	// Classic NIST curves
+	if classicSig, err = ecdsa.SignASN1(rand.Reader, priv.classic, message); err != nil {
+		return nil, err
+	}
+
+	// Concat both to make the hybrid signature
+	hybridSig.AddUint16(uint16(len(classicSig)))
+	hybridSig.AddBytes(classicSig)
+	hybridSig.AddUint16(uint16(len(pqcSig)))
+	hybridSig.AddBytes(pqcSig)
+
+	return hybridSig.BytesOrPanic(), err
+}
+
+func Verify(option uint8, pub PublicKey, signature []byte) (valid bool, err error) {
+	return false, errors.New("not implemented yet")
+}

--- a/src/crypto/hybrid/hybrid_sig.go
+++ b/src/crypto/hybrid/hybrid_sig.go
@@ -30,6 +30,11 @@ const (
 	MAYO3_ED25519 OID = "0.1.3.5"
 	MAYO5_ED25519 OID = "0.1.5.5"
 
+	CROSS_128_SMALL_P256 OID = "0.2.1.1.S"
+	CROSS_128_FAST_P256  OID = "0.2.1.2.F"
+	CROSS_192_SMALL_P384 OID = "0.2.3.3.S"
+	CROSS_256_SMALL_P521 OID = "0.2.5.4.S"
+
 	CROSS_128_SMALL_ED25519 OID = "0.2.1.5.S"
 	CROSS_128_FAST_ED25519  OID = "0.2.1.5.F"
 	CROSS_192_SMALL_ED25519 OID = "0.2.3.5.S"
@@ -51,6 +56,11 @@ var SigOIDtoName = map[OID]SigName{
 	MAYO2_ED25519: {"Mayo-2", ed25519.PrivateKey{}},
 	MAYO3_ED25519: {"Mayo-3", ed25519.PrivateKey{}},
 	MAYO5_ED25519: {"Mayo-5", ed25519.PrivateKey{}},
+
+	CROSS_128_SMALL_P256: {"cross-rsdpg-128-small", elliptic.P256()},
+	CROSS_128_FAST_P256:  {"cross-rsdpg-128-fast", elliptic.P256()},
+	CROSS_192_SMALL_P384: {"cross-rsdpg-192-small", elliptic.P384()},
+	CROSS_256_SMALL_P521: {"cross-rsdpg-256-small", elliptic.P521()},
 
 	CROSS_128_SMALL_ED25519: {"cross-rsdpg-128-small", ed25519.PrivateKey{}},
 	CROSS_128_FAST_ED25519:  {"cross-rsdpg-128-fast", ed25519.PrivateKey{}},


### PR DESCRIPTION
**Descrição**:
Implementa um sistema de assinaturas híbridas para o projeto [BBPQ](https://pqc-group-utfpr.github.io/projects.html).
@Yuuto-Senpai ficaria encarregado de realizar benchmarks e testes.

**Uso geral**:
1. `GenerateKey`: função para criar uma chave privada;
2. `PrivateKey.ExportPublicKey`: método para extrair a chave pública;
3. `PrivateKey.GetPrivateKeys`: método para obter as chaves públicas clássica e PQC;
5. `PrivateKey.Sign`: método para assinar uma mensagem;
6. `PublicKey.GetPublicKeys`: método para obter as chaves públicas clássica e PQC;
7. `Verify`: função para verificar a validade de uma assinatura híbrida, clássica ou PQC.

**Observações**:
- Segui o modelo de struct utilizado em `crypto/ecdsa` e `crypto/rsa`, onde a struct `PrivateKey` encapsula métodos e mantém uma referência para a struct `PublicKey`. Como a função `GenerateKey` retorna apenas a `PrivateKey`, é necessário utilizar um método `PrivateKey.Export*` para acessar a `PublicKey`.
- A assinatura híbrida é a concatenação das assinaturas clássica e PQC, e ela **não** faz parte das structs, sendo somente passada como argumento e retornada pelos métodos e/ou funções. Não sei se seria interessante armazená-la, criando um novo membro `hybrid []byte` na `PublicKey` ou `PrivateKey`;
- Por estar na codebase da go-std, os commits tentam seguir as convenções definidas pelo CONTRIBUTING.md ao invés da Conventional Commits 1.0.0.

Closes: #1 